### PR TITLE
fix: body margin 값 수정 (기존 576~1024 구간 ui 좌측으로 치우침)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -67,7 +67,7 @@ export default function RootLayout({
         GeistMono.variable
       )}
     >
-      <body className="antialiased max-w-xl mx-4 mt-8 lg:mx-auto text-black bg-white dark:text-white dark:bg-black">
+      <body className="antialiased max-w-xl mx-4 mt-8 sm:mx-auto text-black bg-white dark:text-white dark:bg-black">
         <ThemeProvider attribute='class' defaultTheme='light' >
           <main className="flex-auto min-w-0 mt-6 flex flex-col px-2 md:px-0">
             <Navbar />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
   ],
   theme: {
     extend: {},
+    screens: {
+      'sm': '38rem',
+    }
   },
   plugins: [],
   darkMode: 'class'


### PR DESCRIPTION
* as is
  * width가 lg(1024px) 구간 이상에서는 lg:mx-auto로 콘텐츠가 가운데 잘 보여집니다.
  * body의 max-width: 36rem(576px) 으로 고정되어 있을 때 576~1024구간 사이에 mx-4로 인해 body가 왼쪽에 붙어 있습니다.

https://github.com/user-attachments/assets/2f0118a3-8b35-4581-9adb-3de2c81c7caf

* to be
  * 모든 구간에서 콘텐츠를 적절한 위치에 보여질 수 있도록 수정 하였습니다.
  * sm: 38rem => body의 max-width: xl(36rem) + maring-x: 4(1rem * 2) = 38rem

https://github.com/user-attachments/assets/5ea81eca-c861-433d-b4ed-5d44433e760d

